### PR TITLE
Fix autoreview creating new file instead of appending

### DIFF
--- a/autoreview/autoreview.sh
+++ b/autoreview/autoreview.sh
@@ -43,7 +43,7 @@ generate_review_file() {
 generate_review() {
     local review_filename="$1"
     printf "\n" >> "$review_filename"
-    echo "# Code Review for $REPO_NAME at `date -u +"%Y-%dt%H:%M"`" > "$review_filename"
+    echo "# Code Review for $REPO_NAME at `date -u +"%Y-%dt%H:%M"`" >> "$review_filename"
     printf "\n" >> "$review_filename"
     echo "## Here's what I found" >> "$review_filename"
     git diff --cached | mods "$REVIEW_PROMPT" >> "$review_filename"


### PR DESCRIPTION
Hi :wave: , I stumbled upon your repo on https://news.ycombinator.com/item?id=35994037 and had a look. I didn't actually try it so maybe I missed something, but I think the echo of the h1 header for `autoreview` should use `>>` to not create a new file, no?